### PR TITLE
use instance variables instead of class variables.

### DIFF
--- a/lib/stylesheet_flipper/locales.rb
+++ b/lib/stylesheet_flipper/locales.rb
@@ -1,11 +1,11 @@
 module StylesheetFlipper
   def self.flipped_locales
-    @@flipped_locales ||= [:ar, :ckb, :fa, :he, :ug]
+    @flipped_locales ||= [:ar, :ckb, :fa, :he, :ug]
   end
   
   def self.flipped_locales=(value)
     raise ArgumentError.new('flipped_locales should be an array') unless value.is_a?(Array)
     value.map! &:to_sym
-    @@flipped_locales = value
+    @flipped_locales = value
   end
 end


### PR DESCRIPTION
There is no need to use @@ variables on the StylesheetFlipper. And
there are some problems that can happen when using @@ variables so we
should avoid them.
